### PR TITLE
Fix wrong url

### DIFF
--- a/src/plugins/hubpress-github/urls/index.js
+++ b/src/plugins/hubpress-github/urls/index.js
@@ -10,7 +10,7 @@ function getHubpressUrl(meta, windowLocation) {
     windowLocation.host === `${meta.username}.github.io` ||
     windowLocation.host === `${meta.username}.github.com`
   ) {
-    if (meta.branch !== 'master') {
+    if (meta.branch !== 'master' || windowLocation.host !== meta.repositoryName) {
       url = url + '/' + meta.repositoryName
     }
   } else {
@@ -30,7 +30,7 @@ function getSiteUrl(meta, addProtocol) {
   } else {
     url =
       (addProtocol === false ? '' : 'https:') + `//${meta.username}.github.io`
-    if (meta.branch !== 'master') {
+    if (meta.branch !== 'master' || windowLocation.host !== meta.repositoryName) {
       url = url + '/' + meta.repositoryName
     }
   }


### PR DESCRIPTION
You can have github pages on master with repository like https://github.com/kosssi/blog.

![github_pages_config](https://user-images.githubusercontent.com/1135513/32005034-8fcad7c8-b9a3-11e7-8c53-33357488c8b7.png)

You can see the wrong commit https://github.com/kosssi/blog/commit/45a6d888358284e8fe1c74934772ce68c0794deb